### PR TITLE
Remove "Unknown Command" and replace with stats command missing

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,10 +59,11 @@ async def on_message(message):
     if message.content.startswith(data.prefix):
         command_exists = await interpret_command(message)
         if not command_exists:
+            if message.content.startswith("!level") or message.content.startswith("!rank") or message.content.startswith("!stats")
             await functions.send_embed(
                 message.channel,
-                "⚠️ Unknown Command",
-                "If this is a real command, please try again in a few days."
+                "⚠️ Sorry!",
+                "This command is currently not available. Check back in a couple days."
             )
     
     # check message for spam, award points and such


### PR DESCRIPTION
When you say "!", it no longer says "Unknown Command", instead it looks for "!stats" or "!rank" or "!level" and notifies the user that the command is unavailable.

It's annoying when it replies just because you say !