### PR TITLE
Fixed Syntactical Errors

### DIFF
--- a/Modules/commands.py
+++ b/Modules/commands.py
@@ -2,7 +2,8 @@ import discord, json
 from Modules import functions, data
 
 
-async def help(message):
+@asyncio.coroutine
+def help(message):
     # send user the help message
     await functions.send_embed(message.author, "Help", data.help_message)
 

--- a/main.py
+++ b/main.py
@@ -25,7 +25,8 @@ command_list = {
 }
 
 
-async def interpret_command(message):
+@asyncio.coroutine
+def interpret_command(message):
     # check if command exists & get proper command name
     inputted_command = message.content.lower().split()[0]
 


### PR DESCRIPTION
**main.py** : 

> async def interpret_command(message): 
> Using async before a function definition is an only valid syntax in Python 3.4 or greater
> Replaced with @asyncio.coroutine



**Modules/commands.py** :

> async def help(message):
> Using async before a function definition is an only valid syntax in Python 3.4 or greater
> Replaced with @asyncio.coroutine