### PR TITLE
Award system for helpful messages

### DIFF
--- a/modules/data.py
+++ b/modules/data.py
@@ -28,7 +28,7 @@ joins_and_donations = 473852097415086090
 
 # forum for questions where help messages are awarded
 # if you aren't testing this, you can leave this as is
-help_forum = 1059300803145375834
+help_forum = 1043705277976936478
 
 # ids of channels with specific points earned per message (or defaults to 1)
 # if you aren't testing this, you can leave this as is
@@ -71,7 +71,7 @@ nitro_booster = 585533734548406305
 double_xp = 1044338857988075581
 red_colour = 359352595233374208
 
-admin_role = 1059371654049972274
+admin_role = 306155551199461377
 staff_role = 1044304663073280061
 shban_role = 416786636118949918
 aban_role = 550114698297737216

--- a/modules/data.py
+++ b/modules/data.py
@@ -1,11 +1,11 @@
 ### CONFIG - Feel free to change these values when testing the bot.
 
 ### REQUIRED, used to get guild object in on_ready
-server_id = 1058183380254081205
+server_id = 306153640023031820
 
 ### IMPORTANT, it is recommended to set to False if testing
 # setting to False prevents points and ranks from being updated
-award_points = False
+award_points = True
 
 ### IMPORTANT, it is recommended to set to False if testing
 # setting to False prevents helpful messages from being updated

--- a/modules/data.py
+++ b/modules/data.py
@@ -1,11 +1,15 @@
 ### CONFIG - Feel free to change these values when testing the bot.
 
 ### REQUIRED, used to get guild object in on_ready
-server_id = 306153640023031820
+server_id = 1058183380254081205
 
 ### IMPORTANT, it is recommended to set to False if testing
 # setting to False prevents points and ranks from being updated
-award_points = True
+award_points = False
+
+### IMPORTANT, it is recommended to set to False if testing
+# setting to False prevents helpful messages from being updated
+award_help_message = True
 
 # optional, you can leave this as is
 version = "Dr. Script 1.0"
@@ -21,6 +25,10 @@ mod_logs = 332883332528603146
 # channel that new joins and donations are sent to
 # if you aren't testing this, you can leave this as is
 joins_and_donations = 473852097415086090
+
+# forum for questions where help messages are awarded
+# if you aren't testing this, you can leave this as is
+help_forum = 1059300803145375834
 
 # ids of channels with specific points earned per message (or defaults to 1)
 # if you aren't testing this, you can leave this as is
@@ -63,6 +71,7 @@ nitro_booster = 585533734548406305
 double_xp = 1044338857988075581
 red_colour = 359352595233374208
 
+admin_role = 1059371654049972274
 staff_role = 1044304663073280061
 shban_role = 416786636118949918
 aban_role = 550114698297737216

--- a/modules/messages.py
+++ b/modules/messages.py
@@ -77,3 +77,21 @@ async def award_points(message):
     if new_points >= 30:
         if time_now - joined_at >= timedelta(days = 3):
             await process_auto_roles(message, new_points)
+
+
+async def award_help_message(message):
+    # if message isn't significant, ignore it
+    if len(message.content) < 10:
+        return
+
+    # if the message is sent by the author of the post, ignore it
+    if message.author.id == message.channel.owner_id:
+        return
+
+    # get user's data and new help messages count
+    user_id, _, _, _, help_msgs = functions.get_data(message.author.id)
+    new_help_msgs = help_msgs + 1
+
+    # update user's help messages count in database
+    functions.handle_data("UPDATE scores SET helpMsgs = (?) WHERE userId = (?)",
+        (str(new_help_msgs), str(user_id)))


### PR DESCRIPTION
- Database
A new column named `helpMsgs` may be added in `default-scores.sqlite` to persist the amount of helpful messages sent by a user.
- Commands
A new slash command, `\helpstats` has been added for administrators to keep track of the most helpful members without having to directly manipulate `default-scores.sqlite`.
An optional argument indicates whether the leaderboard should be reset, and is left to administrators' discretion.
- Explanation
When a message is sent inside a post in the `scripting-help` forum from a user other than the author of the post, `helpMsgs` count is incremented if the message is relevant enough given its length